### PR TITLE
[Snowservices][User Metrics] Remove metrics stage

### DIFF
--- a/user-metrics/metrics-service.yml.template
+++ b/user-metrics/metrics-service.yml.template
@@ -27,9 +27,6 @@ spec:
         limits:
           memory: 500M
           cpu: 200m
-      volumeMounts:
-        - name: metrics
-          mountPath: /data/prometheus
       command:
         - /bin/prometheus
         - --storage.tsdb.path=/data/prometheus/db
@@ -56,6 +53,4 @@ spec:
     - name: grafana
       port: 3000
       public: true
-  volume:
-    - name: metrics
-      source: "@metrics"
+


### PR DESCRIPTION
In the first iteration we will be storing the prometheus metrics database on the local disk
hence removing the dependency of metrics stage.