### PR TITLE
Log caller token expiry on every request in RCR chatbot

### DIFF
--- a/rcr/ui/Dockerfile
+++ b/rcr/ui/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=python:3.10-slim-buster
 FROM $BASE_IMAGE
 COPY chatbot.py ./
 RUN pip install --upgrade pip && \
-    pip install --upgrade gradio && \
+    pip install "gradio>=5.0,<6.0" && \
     pip install --upgrade requests && \
     pip install --upgrade uvicorn && \
     pip install --upgrade fastapi 

--- a/rcr/ui/chatbot.py
+++ b/rcr/ui/chatbot.py
@@ -29,9 +29,33 @@ app = FastAPI()
 
 @app.middleware("http")
 async def get_ingress_user_token(request: Request, call_next):
-    """Capture the current user token from ingress"""
+    """Capture the current user token from ingress and log its validity"""
     global ingress_user_token
     ingress_user_token = request.headers.get('Sf-Context-Current-User-Token')
+
+    if ingress_user_token:
+        try:
+            url = f"https://{SNOWFLAKE_HOST}/api/v2/statements"
+            headers = {
+                "Authorization": f"Bearer {get_login_token()}",
+                "X-Snowflake-Authorization-Token-Type": "OAUTH",
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+            body = {
+                "statement": "SELECT SYSTEM$GET_SERVICE_CALLER_TOKEN_EXPIRY(?)",
+                "bindings": {"1": {"type": "TEXT", "value": ingress_user_token}}
+            }
+            resp = requests.post(url=url, json=body, headers=headers, timeout=10)
+            if resp.status_code < 400:
+                data = resp.json()
+                expiry = data.get("data", [[None]])[0][0]
+                logger.info(f"Caller token expiry: {expiry}")
+            else:
+                logger.warning(f"Failed to get caller token expiry: HTTP {resp.status_code} - {resp.text[:200]}")
+        except Exception as e:
+            logger.warning(f"Error checking caller token expiry: {e}")
+
     response = await call_next(request)
     return response
 


### PR DESCRIPTION
Add SYSTEM$GET_SERVICE_CALLER_TOKEN_EXPIRY() call in the ingress middleware to log the caller token validity on each request. Pin gradio to 5.x to maintain compatibility with the existing code.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)