### PR TITLE
Fix OAuth authorize URL to use public Snowflake account URL

### DIFF
--- a/rcr_customer_creds_oauth/ui/app.py
+++ b/rcr_customer_creds_oauth/ui/app.py
@@ -93,7 +93,7 @@ async def login(request: Request):
     _purge_expired_states()
 
     auth_url = (
-        f"https://{HOST}/oauth/authorize"
+        f"https://{ACCOUNT}.snowflakecomputing.com/oauth/authorize"
         f"?response_type=code"
         f"&client_id={urllib.parse.quote(OAUTH_CLIENT_ID)}"
         f"&redirect_uri={urllib.parse.quote(redirect_uri)}"


### PR DESCRIPTION
The /authorize redirect was using SNOWFLAKE_HOST (internal SPCS host) instead of the public account URL. The user's browser cannot reach the internal host, so the OAuth flow was broken. Use SNOWFLAKE_ACCOUNT to construct the correct public endpoint instead.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)